### PR TITLE
chore: persist Claude settings and enforce pnpm in devcontainer

### DIFF
--- a/.claude/hooks/check-devcontainer-npm.sh
+++ b/.claude/hooks/check-devcontainer-npm.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Blocks npm usage in devcontainer.json and Dockerfile edits — use pnpm instead.
+input=$(cat)
+
+file=$(echo "$input" | jq -r '.tool_input.file_path // ""')
+echo "$file" | grep -qE '(devcontainer\.json|Dockerfile)' || exit 0
+
+content=$(echo "$input" | jq -r '.tool_input.new_string // .tool_input.content // ""')
+
+# Allow npm install -g npm@latest (bootstrapping npm itself is legitimate)
+stripped=$(echo "$content" | grep -vE 'npm install -g npm(@[a-z0-9.]+)?')
+if echo "$stripped" | grep -qE '(^|[^p])npm'; then
+  echo "Use pnpm instead of npm in devcontainer/Dockerfile configs (e.g. 'pnpm add -g' not 'npm install -g')." >&2
+  exit 2
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/workspaces/stacks/.claude/hooks/check-devcontainer-npm.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,7 @@
 		"ghcr.io/balazs23/devcontainers-features/bazel:1": {},
 		"ghcr.io/itsmechlark/features/postgresql:1": {},
 		"ghcr.io/robbert229/devcontainer-features/postgresql-client:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
 			"moby": true,
 			"installDockerBuildx": true,
@@ -51,9 +52,10 @@
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "npm install -g pnpm"
 	"mounts": [
-		"source=stacks-ssh,target=/home/devcontainer/.ssh,type=volume"
+		"source=stacks-ssh,target=/home/devcontainer/.ssh,type=volume",
+		"source=stacks-claude,target=/home/devcontainer/.claude,type=volume"
 	],
-	"postCreateCommand": "go install github.com/bazelbuild/buildtools/buildifier@latest && git clone https://github.com/bazelbuild/bazel-gazelle.git /tmp/gazelle && cd /tmp/gazelle && go install ./cmd/gazelle && cd .. && rm -rf /tmp/gazelle && go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest"
+	"postCreateCommand": "pnpm add -g @anthropic-ai/claude-code && go install github.com/bazelbuild/buildtools/buildifier@latest && git clone https://github.com/bazelbuild/bazel-gazelle.git /tmp/gazelle && cd /tmp/gazelle && go install ./cmd/gazelle && cd .. && rm -rf /tmp/gazelle && go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest"
 	// Configure tool-specific properties.
 	// "customizations": {},
 	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.


### PR DESCRIPTION
## Summary

- Mount a `stacks-claude` Docker volume to persist `~/.claude` (auth, settings, installed binary) across container rebuilds — same pattern as the existing SSH key volume
- Install `@anthropic-ai/claude-code` via `pnpm add -g` in `postCreateCommand` so the CLI is in PATH and auto-updates work
- Add a `PreToolUse` hook that blocks `npm` usage when editing `devcontainer.json` or Dockerfiles, with a whitelist for `npm install -g npm@latest` (needed to bootstrap npm itself)

## Test plan

- [ ] Rebuild devcontainer and verify `claude` CLI is available in terminal
- [ ] Verify Claude settings persist after container rebuild
- [ ] Try editing devcontainer.json with an npm install command and confirm the hook blocks it

🤖 Generated with [Claude Code](https://claude.com/claude-code)