### PR TITLE
chore: limit Vercel deploys to frontend/ changes only

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- frontend/"
+}


### PR DESCRIPTION
## Summary
- Adds `vercel.json` with `ignoreCommand` to skip Vercel builds when no files under `frontend/` changed
- Prevents unnecessary deploys triggered by changes to docs, openspec, Go/Python service files, etc.

## Test plan
- [ ] Verify a commit touching only non-`frontend/` files results in a skipped Vercel build
- [ ] Verify a commit touching `frontend/` files triggers a normal build

🤖 Generated with [Claude Code](https://claude.com/claude-code)