### PR TITLE
spec: connect-rpc-serverless

### DIFF
--- a/openspec/changes/connect-rpc-serverless/.openspec.yaml
+++ b/openspec/changes/connect-rpc-serverless/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-02

--- a/openspec/changes/connect-rpc-serverless/design.md
+++ b/openspec/changes/connect-rpc-serverless/design.md
@@ -1,0 +1,73 @@
+## Context
+
+The repo has `HelloService` in `api/protos/hello.proto`. Two persistent gRPC servers (Go, Python) exist but are not callable from a browser or Vercel serverless. Connect-RPC adds a browser-compatible HTTP/1.1 layer over the same proto definitions.
+
+This change expands scope to three endpoints in three languages to validate that the proto contract fully abstracts the backend implementation from the frontend client.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Three Connect-RPC serverless functions: TypeScript (`hello`), Go (`yo`), Python (`sup`)
+- All callable from the browser via a single consistent Connect client pattern
+- Generated types never checked in — regenerated from proto at build/deploy time
+- Frontend client code is identical in structure regardless of which language backs the endpoint
+
+**Non-Goals:**
+- Replacing or deprecating the existing Go/Python gRPC servers
+- Authentication, middleware, or streaming RPCs
+- Bazel integration for code generation (use `buf` CLI directly)
+- Shared business logic between the three functions (each is an independent demo)
+
+## Decisions
+
+### Three separate proto files, one per service
+`api/protos/yo.proto` and `api/protos/sup.proto` are added alongside the existing `hello.proto`. Keeps each service definition self-contained and mirrors the pattern already established. One large combined proto file would couple unrelated services.
+
+### Use `buf` CLI for all code generation
+`buf` generates idiomatic types for TypeScript, Go, and Python from a single `buf.gen.yaml`. Alternative (`protoc` with plugins) requires more manual path management. `buf` is pinned via `@bufbuild/buf` npm package so no separate install is needed.
+
+### Generated files are gitignored, regenerated at deploy time
+Generated files (`frontend/src/gen/`, `api/gen/go/`, `api/gen/python/`) are excluded from git. They are fast to generate (seconds) and checking them in creates drift risk when proto files change. The Vercel build command runs `buf generate` before the build step. Locally, developers run `pnpm gen:proto` after proto changes.
+
+### Generated output paths by language
+| Language | Output path | Consumed by |
+|---|---|---|
+| TypeScript | `frontend/src/gen/` | Frontend client + `api/hello.ts` |
+| Go | `api/gen/go/` | `api/yo.go` |
+| Python | `api/gen/python/` | `api/sup.py` |
+
+Go files in `api/gen/go/` are imported by the Go function via the repo's Go module. Python generated files in `api/gen/python/` are on the Python path via `sys.path` insertion in `sup.py` (Vercel Python functions have no package install step for local files).
+
+### Serverless functions live at repo-root `api/`, not `frontend/api/`
+Keeps backend code separate from frontend source. Vercel discovers `api/` functions relative to the repo root when no `rootDirectory` is set in `vercel.json`. The existing `vercel.json` has no `rootDirectory`, so this works without additional config changes beyond updating the build command.
+
+### Cold start characteristics by language
+Go compiles to a binary — fastest cold starts. Node.js is mid-range. Python is slowest due to interpreter startup and import time. All three are acceptable for a demo/learning context on the free tier.
+
+### `buf generate` in Vercel build command
+The `vercel.json` `buildCommand` is updated to: `npx buf generate && cd frontend && pnpm install && pnpm build`. This ensures generated files exist before TypeScript compilation. For Go and Python, Vercel compiles/runs the functions independently — their generated files need to exist at deploy time, covered by the same `buf generate` step.
+
+## Risks / Trade-offs
+
+- **buf not pre-installed on Vercel**: Mitigation — use `npx buf` (via `@bufbuild/buf` in devDependencies) so no global install is required.
+- **Go codegen tools (`protoc-gen-go`, `protoc-gen-connect-go`) must be available at build time**: These are Go binaries. Mitigation — use `buf`'s remote plugins (`buf.build/protocolbuffers/go`, `buf.build/connectrpc/go`) so no local binary install is needed.
+- **Python generated files on sys.path**: Inserting `api/gen/python/` into `sys.path` at runtime is slightly fragile. Mitigation — isolate to a single import block at the top of `sup.py`.
+- **Proto drift if gen:proto not run locally**: Mitigation — CI can verify generated files match proto via `buf generate --error-on-unmanaged` or a diff check. Out of scope for this change but noted.
+
+## React UI
+
+A new **Greetings** tab is added to the frontend navigation alongside the existing tabs. The tab renders three independent cards, one per endpoint:
+
+| Card | Endpoint | Backend |
+|---|---|---|
+| Hello | `/api/hello` | TypeScript / Node.js |
+| Yo | `/api/yo` | Go |
+| Sup | `/api/sup` | Python |
+
+Each card contains:
+- A short description of the endpoint and the backend technology it exercises
+- A text input for the `name` parameter
+- A submit button that triggers the Connect-RPC call independently of the other cards
+- An output area that shows the response message, a loading indicator while in-flight, or a human-readable error on failure
+
+Cards are independent — submitting one does not affect the state of the others.

--- a/openspec/changes/connect-rpc-serverless/proposal.md
+++ b/openspec/changes/connect-rpc-serverless/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The existing HelloService is implemented in Go and Python gRPC servers that run as persistent processes, incompatible with Vercel's serverless model. This change adds three Connect-RPC serverless endpoints — each implemented in a different language (TypeScript, Go, Python) — to demonstrate that the proto contract is the interface boundary and the backend language is an implementation detail invisible to the frontend client.
+
+## What Changes
+
+- Add three proto service definitions (`hello`, `yo`, `sup`) in `api/protos/`
+- Add three Vercel serverless functions in `api/` — one per language:
+  - `api/hello.ts` (Node.js/TypeScript) — `HelloService.SayHello`
+  - `api/yo.go` (Go) — `YoService.SayYo`
+  - `api/sup.py` (Python) — `SupService.SaySup`
+- Generate language-specific types from protos via `buf` — **not checked in**, regenerated at build/deploy time
+- Update Vercel build command to run `buf generate` before the frontend build
+- Add a React component on `/samples` that calls all three endpoints
+
+## Capabilities
+
+### New Capabilities
+- `serverless-connect-rpc`: Three Connect-RPC serverless endpoints in different languages (TypeScript, Go, Python), all callable from the browser via `@connectrpc/connect-web`, with types generated from proto at build time
+
+### Modified Capabilities
+
+## Impact
+
+- **New proto files**: `api/protos/yo.proto`, `api/protos/sup.proto`
+- **New serverless functions**: `api/hello.ts`, `api/yo.go`, `api/sup.py`
+- **Generated (gitignored)**: `frontend/src/gen/` (TS client types), `api/gen/go/` (Go server types), `api/gen/python/` (Python server types)
+- **Build pipeline**: `vercel.json` build command updated to install buf and run `buf generate` before `pnpm build`
+- **Frontend deps**: `@connectrpc/connect`, `@connectrpc/connect-web`, `@connectrpc/connect-node`, `@bufbuild/protobuf`, `@bufbuild/buf`, `@bufbuild/protoc-gen-es`, `@connectrpc/protoc-gen-connect-es`
+- **Existing servers**: Go and Python gRPC servers are unaffected

--- a/openspec/changes/connect-rpc-serverless/specs/serverless-connect-rpc/spec.md
+++ b/openspec/changes/connect-rpc-serverless/specs/serverless-connect-rpc/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Proto definitions for all three services
+The system SHALL define three proto services in `api/protos/`: `HelloService` (existing), `YoService` (new, in `yo.proto`), and `SupService` (new, in `sup.proto`). Each service SHALL have a single unary RPC accepting a `name` field and returning a `message` field.
+
+#### Scenario: YoService proto is valid
+- **WHEN** `buf build` is run at the repo root
+- **THEN** `api/protos/yo.proto` compiles without errors
+
+#### Scenario: SupService proto is valid
+- **WHEN** `buf build` is run at the repo root
+- **THEN** `api/protos/sup.proto` compiles without errors
+
+### Requirement: Generated files excluded from version control
+The system SHALL gitignore all `buf`-generated output directories (`frontend/src/gen/`, `api/gen/go/`, `api/gen/python/`). Generated files SHALL NOT be committed to the repository.
+
+#### Scenario: Generated directories are gitignored
+- **WHEN** `buf generate` has been run and `git status` is checked
+- **THEN** no files under `frontend/src/gen/`, `api/gen/go/`, or `api/gen/python/` appear as untracked or staged
+
+### Requirement: Generated files produced at build time
+The system SHALL regenerate all proto-derived files as part of the Vercel build command before compiling any language-specific code. Locally, running `pnpm gen:proto` from the repo root SHALL regenerate all output directories.
+
+#### Scenario: Build succeeds from clean state
+- **WHEN** all generated directories are deleted and the Vercel build command is run
+- **THEN** `buf generate` runs, generated files are created, and the frontend build completes without errors
+
+### Requirement: TypeScript serverless function for HelloService
+The system SHALL expose `HelloService.SayHello` at `/api/hello` as a Vercel Node.js serverless function written in TypeScript using `@connectrpc/connect-node`. It SHALL return `"Hello, <name>!"`.
+
+#### Scenario: SayHello returns correct greeting
+- **WHEN** a Connect-RPC client calls `SayHello` with `name` set to `"World"`
+- **THEN** the response `message` equals `"Hello, World!"`
+
+### Requirement: Go serverless function for YoService
+The system SHALL expose `YoService.SayYo` at `/api/yo` as a Vercel Go serverless function using `connectrpc.com/connect`. It SHALL return `"Yo, <name>!"`.
+
+#### Scenario: SayYo returns correct greeting
+- **WHEN** a Connect-RPC client calls `SayYo` with `name` set to `"World"`
+- **THEN** the response `message` equals `"Yo, World!"`
+
+### Requirement: Python serverless function for SupService
+The system SHALL expose `SupService.SaySup` at `/api/sup` as a Vercel Python serverless function. It SHALL return `"Sup, <name>!"`.
+
+#### Scenario: SaySup returns correct greeting
+- **WHEN** a Connect-RPC client calls `SaySup` with `name` set to `"World"`
+- **THEN** the response `message` equals `"Sup, World!"`
+
+### Requirement: React client integration for all three endpoints
+The system SHALL add a new **Greetings** tab to the frontend navigation. The tab SHALL contain three independent cards — one for `/api/hello` (TypeScript), one for `/api/yo` (Go), and one for `/api/sup` (Python) — each implemented using `@connectrpc/connect-web`. Each card SHALL include a short description of the endpoint and the backing technology, a text input for the `name` parameter, a submit button, and an output area that shows the response message, a loading indicator while the request is in flight, or a human-readable error on failure. Submitting one card SHALL NOT affect the state of the other cards.
+
+#### Scenario: User submits a greeting card
+- **WHEN** a user navigates to the Greetings tab, types a name into a card's input, and clicks its submit button
+- **THEN** that card independently calls its endpoint and displays the returned greeting
+
+#### Scenario: Loading state shown
+- **WHEN** any Connect client request is pending
+- **THEN** the corresponding card displays a loading indicator
+
+#### Scenario: Error state shown
+- **WHEN** any Connect client request fails
+- **THEN** the corresponding card displays a human-readable error message
+
+#### Scenario: Cards are independent
+- **WHEN** a user submits one card while another card is loading or has an error
+- **THEN** each card's state is unaffected by the other cards

--- a/openspec/changes/connect-rpc-serverless/tasks.md
+++ b/openspec/changes/connect-rpc-serverless/tasks.md
@@ -1,0 +1,48 @@
+## 1. Proto Definitions
+
+- [ ] 1.1 Add `api/protos/yo.proto` — define `YoService` with `SayYo(YoRequest) → YoResponse` (same structure as `hello.proto`)
+- [ ] 1.2 Add `api/protos/sup.proto` — define `SupService` with `SaySup(SupRequest) → SupResponse`
+
+## 2. buf Code Generation Setup
+
+- [ ] 2.1 Add `buf.yaml` at the repo root declaring the proto module (path `api/protos`)
+- [ ] 2.2 Add `buf.gen.yaml` at the repo root with three output targets:
+  - TypeScript (messages + connect-es) → `frontend/src/gen/`
+  - Go (protoc-gen-go + protoc-gen-connect-go) → `api/gen/go/` using remote plugins
+  - Python (protoc-gen-python + betterproto or connect-python) → `api/gen/python/`
+- [ ] 2.3 Add `@bufbuild/buf`, `@bufbuild/protoc-gen-es`, and `@connectrpc/protoc-gen-connect-es` as devDependencies in `frontend/package.json`
+- [ ] 2.4 Add a `gen:proto` script in `frontend/package.json` (or root `package.json`) that runs `buf generate` from the repo root
+- [ ] 2.5 Add `frontend/src/gen/`, `api/gen/go/`, and `api/gen/python/` to `.gitignore`
+- [ ] 2.6 Run `pnpm gen:proto` and verify all three output directories are populated
+- [ ] 2.7 Update `vercel.json` `buildCommand` to run `npx buf generate` before `cd frontend && pnpm install && pnpm build`
+
+## 3. TypeScript Serverless Function (hello)
+
+- [ ] 3.1 Add `@connectrpc/connect`, `@connectrpc/connect-node`, and `@bufbuild/protobuf` as dependencies in `frontend/package.json`
+- [ ] 3.2 Create `api/hello.ts` — Connect router registering `HelloService` returning `"Hello, <name>!"`, exported via `toNodeHttpHandler`
+- [ ] 3.3 Verify `api/hello.ts` typechecks (ensure `tsconfig` in repo root or `api/` covers the file)
+
+## 4. Go Serverless Function (yo)
+
+- [ ] 4.1 Add `connectrpc.com/connect` and generated Go proto dependencies to `go.mod` / `go.sum`
+- [ ] 4.2 Create `api/yo.go` — `package handler`, `Handler(w http.ResponseWriter, r *http.Request)`, Connect router registering `YoService` returning `"Yo, <name>!"`
+
+## 5. Python Serverless Function (sup)
+
+- [ ] 5.1 Add `connect-python` (or equivalent) and `protobuf` to `api/requirements.txt` (Vercel installs this for the Python runtime)
+- [ ] 5.2 Create `api/sup.py` — Vercel Python handler function, inserts `api/gen/python/` onto `sys.path`, registers `SupService` returning `"Sup, <name>!"`
+
+## 6. React Client Integration
+
+- [ ] 6.1 Add `@connectrpc/connect-web` as a dependency in `frontend/package.json`
+- [ ] 6.2 Create `frontend/src/features/greetings/HelloCard.tsx` — description label ("Hello · TypeScript / Node.js"), name input, submit button, Connect client to `/api/hello`, renders response/loading/error
+- [ ] 6.3 Create `frontend/src/features/greetings/YoCard.tsx` — description label ("Yo · Go"), name input, submit button, Connect client to `/api/yo`, renders response/loading/error
+- [ ] 6.4 Create `frontend/src/features/greetings/SupCard.tsx` — description label ("Sup · Python"), name input, submit button, Connect client to `/api/sup`, renders response/loading/error
+- [ ] 6.5 Add a new **Greetings** route/tab to the frontend navigation (alongside existing tabs)
+- [ ] 6.6 Create the Greetings page and render all three cards side-by-side (each card manages its own state independently)
+
+## 7. Verification
+
+- [ ] 7.1 Run `pnpm dev` and confirm all three greeting cards call their endpoints and display responses
+- [ ] 7.2 Run `pnpm build` and confirm no TypeScript errors
+- [ ] 7.3 Run `pnpm lint` and confirm no lint errors


### PR DESCRIPTION
## Summary
- Three Connect-RPC serverless endpoints in TypeScript, Go, and Python backed by shared proto contracts
- Generated files gitignored and regenerated via `buf generate` at build/deploy time
- New Greetings tab in frontend with three independent cards (name input, submit, output)

## Artifacts
- `proposal.md` — why and what changes
- `design.md` — architectural decisions, output paths, Vercel build command, UI layout
- `specs/serverless-connect-rpc/spec.md` — requirements and scenarios
- `tasks.md` — 21 implementation tasks across 7 groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)