### PR TITLE
feat: connect-rpc foundation (proto + buf config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,7 @@ yarn-error.log*
 *.out
 /vendor/
 
-
-
+# buf generated output
+frontend/src/gen/
+api/gen/go/
+api/gen/python/

--- a/api/protos/sup.proto
+++ b/api/protos/sup.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package adam.sup;
+
+option go_package = "adam/sup";
+
+message SupRequest { string name = 1; }
+message SupResponse { string message = 1; }
+service SupService {
+  rpc SaySup (SupRequest) returns (SupResponse) {}
+}

--- a/api/protos/yo.proto
+++ b/api/protos/yo.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package adam.yo;
+
+option go_package = "adam/yo";
+
+message YoRequest { string name = 1; }
+message YoResponse { string message = 1; }
+service YoService {
+  rpc SayYo (YoRequest) returns (YoResponse) {}
+}

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,0 +1,21 @@
+version: v2
+plugins:
+  # TypeScript: protobuf messages
+  - remote: buf.build/bufbuild/es
+    out: frontend/src/gen
+    opt: target=ts
+  # TypeScript: Connect service clients/handlers
+  - remote: buf.build/connectrpc/es
+    out: frontend/src/gen
+    opt: target=ts
+  # Go: protobuf messages
+  - remote: buf.build/protocolbuffers/go
+    out: api/gen/go
+    opt: paths=source_relative
+  # Go: Connect service handlers
+  - remote: buf.build/connectrpc/go
+    out: api/gen/go
+    opt: paths=source_relative
+  # Python: protobuf messages
+  - remote: buf.build/protocolbuffers/python
+    out: api/gen/python

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,3 @@
+version: v2
+modules:
+  - path: api/protos

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,9 +7,13 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "gen:proto": "buf generate"
   },
   "devDependencies": {
+    "@bufbuild/buf": "latest",
+    "@bufbuild/protoc-gen-es": "latest",
+    "@connectrpc/protoc-gen-connect-es": "latest",
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.5.0",
     "@vitejs/plugin-react": "^6.0.1",
@@ -22,6 +26,10 @@
     "vite": "^8.0.3"
   },
   "dependencies": {
+    "@bufbuild/protobuf": "latest",
+    "@connectrpc/connect": "latest",
+    "@connectrpc/connect-node": "latest",
+    "@connectrpc/connect-web": "latest",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,4 @@
 {
-  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- frontend/"
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- frontend/",
+  "buildCommand": "npx buf generate && cd frontend && pnpm install && pnpm build"
 }


### PR DESCRIPTION
## Summary

- Add `api/protos/yo.proto` — defines `YoService` with `SayYo` RPC
- Add `api/protos/sup.proto` — defines `SupService` with `SaySup` RPC
- Add `buf.yaml` at repo root — buf v2 config pointing at `api/protos`
- Add `buf.gen.yaml` at repo root — code generation config for TypeScript (protobuf-es + connect-es), Go (protobuf + connect-go), and Python
- Update `frontend/package.json` — add `gen:proto` script; add `@bufbuild/buf`, `@bufbuild/protoc-gen-es`, `@connectrpc/protoc-gen-connect-es` to devDependencies; add `@bufbuild/protobuf`, `@connectrpc/connect`, `@connectrpc/connect-web`, `@connectrpc/connect-node` to dependencies
- Update `.gitignore` — ignore `frontend/src/gen/`, `api/gen/go/`, `api/gen/python/` (buf generated output)
- Update `vercel.json` — add `buildCommand` to run `buf generate` before frontend build

## Test plan

- [ ] Verify `buf.yaml` and `buf.gen.yaml` are valid by running `npx buf generate` (optional, not required for merge)
- [ ] Confirm proto files match the style of `api/protos/hello.proto`
- [ ] Confirm `.gitignore` entries cover all generated output directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)