### PR TITLE
feat: React Greetings tab — Connect-RPC client cards

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import "./App.css";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
-import { Home, Learner, Samples } from "@features/index";
+import { Greetings, Home, Learner, Samples } from "@features/index";
 import { Header } from "@components/Header";
 
 function App() {
@@ -15,6 +15,7 @@ function App() {
             <Route path="/samples" element={<Samples />} />
             <Route path="/samples/:count" element={<Samples />} />
             <Route path="/learner" element={<Learner />} />
+            <Route path="/greetings" element={<Greetings />} />
           </Routes>
         </main>
       </div>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -27,6 +27,12 @@ export const Header: React.FC = () => {
           >
             Learner
           </NavLink>
+          <NavLink
+            to="/greetings"
+            className={({ isActive }) => isActive ? "nav-link nav-link--active" : "nav-link"}
+          >
+            Greetings
+          </NavLink>
         </nav>
         <ThemeDropdown />
       </div>

--- a/frontend/src/features/greetings/Greetings.tsx
+++ b/frontend/src/features/greetings/Greetings.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { HelloCard } from "./HelloCard";
+import { YoCard } from "./YoCard";
+import { SupCard } from "./SupCard";
+import "./greetings.css";
+
+export const Greetings: React.FC = () => {
+  return (
+    <div className="greetings">
+      <h1 className="greetings__title">Connect-RPC Greetings</h1>
+      <p className="greetings__subtitle">Three endpoints, three languages — one proto contract.</p>
+      <div className="greetings__cards">
+        <HelloCard />
+        <YoCard />
+        <SupCard />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/greetings/HelloCard.tsx
+++ b/frontend/src/features/greetings/HelloCard.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+import { createConnectTransport } from "@connectrpc/connect-web";
+import { createClient } from "@connectrpc/connect";
+import { HelloService } from "../../gen/hello_connect.js";
+import { HelloRequest } from "../../gen/hello_pb.js";
+
+const transport = createConnectTransport({ baseUrl: "" });
+const client = createClient(HelloService, transport);
+
+export const HelloCard: React.FC = () => {
+  const [name, setName] = useState("");
+  const [result, setResult] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setResult(null);
+    setError(null);
+    try {
+      const res = await client.sayHello(new HelloRequest({ name }));
+      setResult(res.message);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Request failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="greeting-card">
+      <p className="greeting-card__description">Hello · TypeScript / Node.js</p>
+      <form className="greeting-card__form" onSubmit={handleSubmit}>
+        <input
+          className="greeting-card__input"
+          type="text"
+          placeholder="Enter name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <button className="greeting-card__submit" type="submit" disabled={loading}>
+          Send
+        </button>
+      </form>
+      {loading && <p className="greeting-card__status greeting-card__status--loading">Loading…</p>}
+      {result && <p className="greeting-card__status greeting-card__status--result">{result}</p>}
+      {error && <p className="greeting-card__status greeting-card__status--error">{error}</p>}
+    </div>
+  );
+};

--- a/frontend/src/features/greetings/SupCard.tsx
+++ b/frontend/src/features/greetings/SupCard.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+import { createConnectTransport } from "@connectrpc/connect-web";
+import { createClient } from "@connectrpc/connect";
+import { SupService } from "../../gen/sup_connect.js";
+import { SupRequest } from "../../gen/sup_pb.js";
+
+const transport = createConnectTransport({ baseUrl: "" });
+const client = createClient(SupService, transport);
+
+export const SupCard: React.FC = () => {
+  const [name, setName] = useState("");
+  const [result, setResult] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setResult(null);
+    setError(null);
+    try {
+      const res = await client.saySup(new SupRequest({ name }));
+      setResult(res.message);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Request failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="greeting-card">
+      <p className="greeting-card__description">Sup · Python</p>
+      <form className="greeting-card__form" onSubmit={handleSubmit}>
+        <input
+          className="greeting-card__input"
+          type="text"
+          placeholder="Enter name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <button className="greeting-card__submit" type="submit" disabled={loading}>
+          Send
+        </button>
+      </form>
+      {loading && <p className="greeting-card__status greeting-card__status--loading">Loading…</p>}
+      {result && <p className="greeting-card__status greeting-card__status--result">{result}</p>}
+      {error && <p className="greeting-card__status greeting-card__status--error">{error}</p>}
+    </div>
+  );
+};

--- a/frontend/src/features/greetings/YoCard.tsx
+++ b/frontend/src/features/greetings/YoCard.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+import { createConnectTransport } from "@connectrpc/connect-web";
+import { createClient } from "@connectrpc/connect";
+import { YoService } from "../../gen/yo_connect.js";
+import { YoRequest } from "../../gen/yo_pb.js";
+
+const transport = createConnectTransport({ baseUrl: "" });
+const client = createClient(YoService, transport);
+
+export const YoCard: React.FC = () => {
+  const [name, setName] = useState("");
+  const [result, setResult] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setResult(null);
+    setError(null);
+    try {
+      const res = await client.sayYo(new YoRequest({ name }));
+      setResult(res.message);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Request failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="greeting-card">
+      <p className="greeting-card__description">Yo · Go</p>
+      <form className="greeting-card__form" onSubmit={handleSubmit}>
+        <input
+          className="greeting-card__input"
+          type="text"
+          placeholder="Enter name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <button className="greeting-card__submit" type="submit" disabled={loading}>
+          Send
+        </button>
+      </form>
+      {loading && <p className="greeting-card__status greeting-card__status--loading">Loading…</p>}
+      {result && <p className="greeting-card__status greeting-card__status--result">{result}</p>}
+      {error && <p className="greeting-card__status greeting-card__status--error">{error}</p>}
+    </div>
+  );
+};

--- a/frontend/src/features/greetings/greetings.css
+++ b/frontend/src/features/greetings/greetings.css
@@ -1,0 +1,104 @@
+.greetings {
+  padding: var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xl);
+}
+
+.greetings__title {
+  font-size: var(--font-size-xl);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.greetings__subtitle {
+  font-size: var(--font-size-md);
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.greetings__cards {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: var(--spacing-lg);
+}
+
+.greeting-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  padding: var(--card-padding);
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--border-radius);
+  min-width: 240px;
+  flex: 1;
+}
+
+.greeting-card__description {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  margin: 0;
+  font-weight: 500;
+}
+
+.greeting-card__form {
+  display: flex;
+  flex-direction: row;
+  gap: var(--spacing-sm);
+}
+
+.greeting-card__input {
+  flex: 1;
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: var(--font-size-md);
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--border-radius);
+  outline: none;
+}
+
+.greeting-card__input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 25%, transparent);
+}
+
+.greeting-card__submit {
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: var(--font-size-md);
+  color: var(--bg-primary);
+  background-color: var(--accent);
+  border: none;
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.greeting-card__submit:hover:not(:disabled) {
+  background-color: var(--accent-hover);
+}
+
+.greeting-card__submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.greeting-card__status {
+  font-size: var(--font-size-md);
+  margin: 0;
+}
+
+.greeting-card__status--loading {
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.greeting-card__status--result {
+  color: var(--text-primary);
+}
+
+.greeting-card__status--error {
+  color: var(--error, #e53e3e);
+}

--- a/frontend/src/features/greetings/index.ts
+++ b/frontend/src/features/greetings/index.ts
@@ -1,0 +1,1 @@
+export * from "./Greetings";

--- a/frontend/src/features/index.ts
+++ b/frontend/src/features/index.ts
@@ -1,3 +1,4 @@
 export * from './home'
 export * from './samples'
 export * from './learner'
+export * from './greetings'


### PR DESCRIPTION
## Summary
- New `/greetings` route and nav link in `Header`
- `frontend/src/features/greetings/` — three independent cards:
  - `HelloCard` → `/api/hello` (TypeScript / Node.js)
  - `YoCard` → `/api/yo` (Go)
  - `SupCard` → `/api/sup` (Python)
- Each card: description label, name text input, submit button, output/loading/error display
- Cards manage their own state independently

## Test plan
- [ ] Navigate to /greetings — three cards render
- [ ] Type a name in each card and submit — each calls its endpoint independently
- [ ] Loading and error states display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)