### PR TITLE
fix: correct Vercel ignoreCommand and buildCommand

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
-  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- frontend/",
-  "buildCommand": "npx buf generate && cd frontend && pnpm install && pnpm build"
+  "ignoreCommand": "git diff HEAD^ HEAD --name-only -- frontend/ api/ | grep -q .",
+  "buildCommand": "pnpm install && (cd .. && ./frontend/node_modules/.bin/buf generate) && pnpm build"
 }


### PR DESCRIPTION
## Problem
Two bugs in `vercel.json` that have been cancelling all deployments since PR #9:

**1. `ignoreCommand` was backwards**
Vercel's convention: exit 0 = proceed, exit 1 = cancel. But `git diff --quiet` exits 1 when changes *exist*, so the command was cancelling every deployment that touched `frontend/` and proceeding for commits with no frontend changes.

**2. `buildCommand` broken for `rootDirectory: "frontend"`**
The Vercel project has `rootDirectory: "frontend"` set in the dashboard. Vercel runs the build command from `frontend/`. Our command `cd frontend && pnpm install` tried to enter `frontend/frontend/` and failed. Also `npx buf generate` ran before `pnpm install`, so `@bufbuild/buf` wasn't installed yet.

## Fix
- `ignoreCommand`: switched to `git diff --name-only | grep -q .` which exits 0 (proceed) when changes are found. Expanded to cover `api/` so serverless function changes also trigger a deploy.
- `buildCommand`: `pnpm install` first (installs `buf`), then run `buf generate` from repo root via subshell `(cd .. && ./frontend/node_modules/.bin/buf generate)`, then `pnpm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)