### PR TITLE
chore: move Vercel build config into vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,7 @@
 {
-  "ignoreCommand": "git diff HEAD^ HEAD --name-only -- frontend/ api/ | grep -q .",
-  "buildCommand": "pnpm install && (cd .. && ./frontend/node_modules/.bin/buf generate) && pnpm build"
+  "framework": "vite",
+  "installCommand": "pnpm install --prefix frontend",
+  "buildCommand": "frontend/node_modules/.bin/buf generate && pnpm build --prefix frontend",
+  "outputDirectory": "frontend/dist",
+  "ignoreCommand": "git diff HEAD^ HEAD --name-only -- frontend/ api/ | grep -q ."
 }


### PR DESCRIPTION
## Summary
- `rootDirectory` changed to `./` in Vercel dashboard (one-time change)
- All build config now in `vercel.json`: `framework`, `installCommand`, `buildCommand`, `outputDirectory`
- Removes the `(cd .. && ...)` subshell workaround that was compensating for `rootDirectory: frontend`
- `installCommand` runs `pnpm install --prefix frontend` first so `buf` binary is available for `buildCommand`

🤖 Generated with [Claude Code](https://claude.com/claude-code)