### PR TITLE
fix: resolve Vercel Go build errors

### DIFF
--- a/service/simple/simple.go
+++ b/service/simple/simple.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "framework": "vite",
-  "installCommand": "pnpm install --prefix frontend",
-  "buildCommand": "frontend/node_modules/.bin/buf generate && pnpm build --prefix frontend",
+  "installCommand": "pnpm install --prefix frontend && frontend/node_modules/.bin/buf generate",
+  "buildCommand": "pnpm build --prefix frontend",
   "outputDirectory": "frontend/dist",
   "ignoreCommand": "git diff HEAD^ HEAD --name-only -- frontend/ api/ | grep -q ."
 }


### PR DESCRIPTION
## Problems
Two errors in the Vercel build for Go serverless functions:

**1. `service/simple/simple.go` pulled into Go compilation**
Vercel scans all Go files in the module. `service/simple/simple.go` imports `com.github/maybecake/stacks/api/protos/hello` — a Bazel-specific path that doesn't exist outside Bazel. Added `//go:build ignore` to exclude it from standard `go build`.

**2. Generated Go files missing at compile time**
`buf generate` was in `buildCommand` but Vercel compiles Go serverless functions before `buildCommand` runs. Moved `buf generate` into `installCommand` so `api/gen/go/` exists when the Go function is compiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)