### PR TITLE
chore: trigger deploy after Go build fixes

### DIFF
--- a/api/yo.go
+++ b/api/yo.go
@@ -24,3 +24,4 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	mux.Handle(path, handler)
 	mux.ServeHTTP(w, r)
 }
+


### PR DESCRIPTION
Trivial whitespace change to trigger Vercel deployment after fixing Go build errors in #15.