### PR TITLE
fix: ignoreCommand resilient to depth-1 shallow clone

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,5 @@
   "installCommand": "pnpm install --prefix frontend && frontend/node_modules/.bin/buf generate",
   "buildCommand": "pnpm build --prefix frontend",
   "outputDirectory": "frontend/dist",
-  "ignoreCommand": "git diff HEAD^ HEAD --name-only -- frontend/ api/ | grep -q ."
+  "ignoreCommand": "git rev-parse HEAD^ >/dev/null 2>&1 || exit 0; git diff HEAD^ HEAD --name-only -- frontend/ api/ | grep -q ."
 }


### PR DESCRIPTION
## Problem
Vercel clones with `--depth 1`. `HEAD^` doesn't exist in the clone, so `git diff HEAD^ HEAD` fails immediately with no output. `grep -q .` on empty input exits 1, so Vercel cancels every build — including ones that should deploy.

## Fix
```bash
git rev-parse HEAD^ >/dev/null 2>&1 || exit 0; git diff HEAD^ HEAD --name-only -- frontend/ api/ | grep -q .
```
- If `HEAD^` can't be resolved (shallow clone): `exit 0` → always build
- If `HEAD^` exists: run the normal diff filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)