### PR TITLE
chore: remove ignoreCommand

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,5 @@
   "framework": "vite",
   "installCommand": "pnpm install --prefix frontend && frontend/node_modules/.bin/buf generate",
   "buildCommand": "pnpm build --prefix frontend",
-  "outputDirectory": "frontend/dist",
-  "ignoreCommand": "git rev-parse HEAD^ >/dev/null 2>&1 || exit 0; git diff HEAD^ HEAD --name-only -- frontend/ api/ | grep -q ."
+  "outputDirectory": "frontend/dist"
 }


### PR DESCRIPTION
Vercel's shallow clone breaks git diff HEAD^ HEAD. Just remove it and always build.