### PR TITLE
fix(pagination): push LIMIT/OFFSET into SQL instead of slicing in-process

### DIFF
--- a/lib/adapters/postgres/db/greeting.sql.go
+++ b/lib/adapters/postgres/db/greeting.sql.go
@@ -88,6 +88,82 @@ func (q *Queries) InsertGreetingLog(ctx context.Context, arg InsertGreetingLogPa
 	return err
 }
 
+const listGreetedNamesPaginated = `-- name: ListGreetedNamesPaginated :many
+SELECT name, COUNT(*) AS count
+FROM greeting_log
+GROUP BY name
+ORDER BY count DESC
+LIMIT $1 OFFSET $2
+`
+
+type ListGreetedNamesPaginatedParams struct {
+	Limit  int32 `json:"limit"`
+	Offset int32 `json:"offset"`
+}
+
+type ListGreetedNamesPaginatedRow struct {
+	Name  string `json:"name"`
+	Count int64  `json:"count"`
+}
+
+func (q *Queries) ListGreetedNamesPaginated(ctx context.Context, arg ListGreetedNamesPaginatedParams) ([]ListGreetedNamesPaginatedRow, error) {
+	rows, err := q.db.QueryContext(ctx, listGreetedNamesPaginated, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListGreetedNamesPaginatedRow
+	for rows.Next() {
+		var i ListGreetedNamesPaginatedRow
+		if err := rows.Scan(&i.Name, &i.Count); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listGreetingTypeStatsPaginated = `-- name: ListGreetingTypeStatsPaginated :many
+SELECT greeting_type, count
+FROM greeting_stats
+ORDER BY greeting_type
+LIMIT $1 OFFSET $2
+`
+
+type ListGreetingTypeStatsPaginatedParams struct {
+	Limit  int32 `json:"limit"`
+	Offset int32 `json:"offset"`
+}
+
+func (q *Queries) ListGreetingTypeStatsPaginated(ctx context.Context, arg ListGreetingTypeStatsPaginatedParams) ([]GreetingStat, error) {
+	rows, err := q.db.QueryContext(ctx, listGreetingTypeStatsPaginated, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GreetingStat
+	for rows.Next() {
+		var i GreetingStat
+		if err := rows.Scan(&i.GreetingType, &i.Count); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const upsertGreetingStats = `-- name: UpsertGreetingStats :exec
 INSERT INTO greeting_stats (greeting_type, count)
 VALUES ($1, 1)

--- a/lib/adapters/postgres/greeting_store.go
+++ b/lib/adapters/postgres/greeting_store.go
@@ -75,55 +75,52 @@ func (s *PostgresGreetingStore) GetNameFrequencies(ctx context.Context) ([]domai
 	return freqs, nil
 }
 
-// ListGreetingTypeStats delegates to GetStats and applies in-process pagination.
-// A real implementation would push pagination into the SQL query.
 func (s *PostgresGreetingStore) ListGreetingTypeStats(ctx context.Context, limit int, cursor string) ([]domain.GreetingTypeStat, string, error) {
-	all, err := s.GetStats(ctx)
-	if err != nil {
-		return nil, "", err
-	}
 	offset, err := pagination.DecodeCursor(cursor)
 	if err != nil {
 		return nil, "", err
 	}
-	if offset >= len(all) {
-		return []domain.GreetingTypeStat{}, "", nil
-	}
-	page := all[offset:]
-	if len(page) > limit {
-		page = page[:limit]
-	}
-	typed := make([]domain.GreetingTypeStat, len(page))
-	for i, s := range page {
-		typed[i] = domain.GreetingTypeStat{GreetingType: s.GreetingType, Count: s.Count}
+	q := pgdb.New(s.db)
+	rows, err := q.ListGreetingTypeStatsPaginated(ctx, pgdb.ListGreetingTypeStatsPaginatedParams{
+		Limit:  int32(limit + 1),
+		Offset: int32(offset),
+	})
+	if err != nil {
+		return nil, "", err
 	}
 	nextCursor := ""
-	if offset+len(typed) < len(all) {
-		nextCursor = pagination.EncodeCursor(offset + len(typed))
+	if len(rows) > limit {
+		rows = rows[:limit]
+		nextCursor = pagination.EncodeCursor(offset + limit)
 	}
-	return typed, nextCursor, nil
+	items := make([]domain.GreetingTypeStat, len(rows))
+	for i, r := range rows {
+		items[i] = domain.GreetingTypeStat{GreetingType: r.GreetingType, Count: int64(r.Count)}
+	}
+	return items, nextCursor, nil
 }
 
-// ListGreetedNames delegates to GetNameFrequencies and applies in-process pagination.
 func (s *PostgresGreetingStore) ListGreetedNames(ctx context.Context, limit int, cursor string) ([]domain.NameFrequency, string, error) {
-	all, err := s.GetNameFrequencies(ctx)
-	if err != nil {
-		return nil, "", err
-	}
 	offset, err := pagination.DecodeCursor(cursor)
 	if err != nil {
 		return nil, "", err
 	}
-	if offset >= len(all) {
-		return []domain.NameFrequency{}, "", nil
-	}
-	page := all[offset:]
-	if len(page) > limit {
-		page = page[:limit]
+	q := pgdb.New(s.db)
+	rows, err := q.ListGreetedNamesPaginated(ctx, pgdb.ListGreetedNamesPaginatedParams{
+		Limit:  int32(limit + 1),
+		Offset: int32(offset),
+	})
+	if err != nil {
+		return nil, "", err
 	}
 	nextCursor := ""
-	if offset+len(page) < len(all) {
-		nextCursor = pagination.EncodeCursor(offset + len(page))
+	if len(rows) > limit {
+		rows = rows[:limit]
+		nextCursor = pagination.EncodeCursor(offset + limit)
 	}
-	return page, nextCursor, nil
+	items := make([]domain.NameFrequency, len(rows))
+	for i, r := range rows {
+		items[i] = domain.NameFrequency{Name: r.Name, Count: r.Count}
+	}
+	return items, nextCursor, nil
 }

--- a/lib/adapters/postgres/queries/greeting.sql
+++ b/lib/adapters/postgres/queries/greeting.sql
@@ -18,3 +18,16 @@ SELECT name, COUNT(*) AS count
 FROM greeting_log
 GROUP BY name
 ORDER BY count DESC;
+
+-- name: ListGreetingTypeStatsPaginated :many
+SELECT greeting_type, count
+FROM greeting_stats
+ORDER BY greeting_type
+LIMIT $1 OFFSET $2;
+
+-- name: ListGreetedNamesPaginated :many
+SELECT name, COUNT(*) AS count
+FROM greeting_log
+GROUP BY name
+ORDER BY count DESC
+LIMIT $1 OFFSET $2;


### PR DESCRIPTION
## Summary

- `ListGreetingTypeStats` and `ListGreetedNames` in the Postgres adapter were fetching **all rows** from the DB and slicing them in Go — O(n) memory and unnecessary data transfer on every list call
- Added two new sqlc queries (`ListGreetingTypeStatsPaginated`, `ListGreetedNamesPaginated`) with `LIMIT $1 OFFSET $2` pushed to Postgres
- Rewrote the store methods to use the paginated queries; uses the `limit+1` trick to detect next-page existence without a separate `COUNT(*)` query
- Regenerated `greeting.sql.go` via `sqlc generate`

## Test plan

- [ ] List with no page token returns first page with correct `next_page_token`
- [ ] Passing the returned token returns the next page
- [ ] Last page returns empty `next_page_token`
- [ ] `page_size` of 0 defaults to 20; values above 100 are clamped

🤖 Generated with [Claude Code](https://claude.com/claude-code)