### PR TITLE
Fix devcontainer chown failure on macOS Docker Desktop

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -67,5 +67,5 @@
     "source=stacks-vercel,target=/home/devcontainer/.local/share/com.vercel.cli,type=volume"
   ],
   "postCreateCommand": "bash .devcontainer/post-create.sh",
-  "postStartCommand": "sudo chown -R devcontainer:devcontainer /workspaces/stacks ~/"
+  "postStartCommand": "sudo chown -R devcontainer:devcontainer /workspaces/stacks ~/ 2>/dev/null || true"
 }


### PR DESCRIPTION
## Summary
- `postStartCommand` was failing with `Permission denied` on `.git/objects/pack/` files when opening the dev container on macOS with Docker Desktop
- Added `2>/dev/null || true` to suppress errors on files that can't be chowned due to macOS VirtioFS/gRPC-FUSE UID namespace restrictions
- These git pack files don't need `devcontainer` ownership — they're read-only git internals

🤖 Generated with [Claude Code](https://claude.com/claude-code)