### PR TITLE
Fix mobile nav staying open when rotating to landscape

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { NavLink } from "react-router-dom";
 import { Show, SignInButton, UserButton } from "@clerk/react";
@@ -5,6 +6,8 @@ import { ThemeDropdown } from "./ThemeDropdown";
 import { Logo } from "@ui/Logo";
 import "./header.css";
 import { Button } from "@ui/button";
+
+const MOBILE_BREAKPOINT = 768;
 
 const NAV_LINKS = [
   { to: "/samples", label: "Samples" },
@@ -18,8 +21,19 @@ const navLinkClass = ({ isActive }: { isActive: boolean }) =>
   isActive ? "nav-link nav-link--active" : "nav-link";
 
 export const Header = () => {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT}px)`);
+    const handleChange = (e: MediaQueryListEvent) => {
+      if (!e.matches) setOpen(false);
+    };
+    mql.addEventListener("change", handleChange);
+    return () => mql.removeEventListener("change", handleChange);
+  }, []);
+
   return (
-    <Collapsible.Root>
+    <Collapsible.Root open={open} onOpenChange={setOpen}>
       <header className="header">
         <div className="header-content">
           <NavLink to="/" className="header-home">


### PR DESCRIPTION
## Summary

- Mobile hamburger nav could get stuck open when rotating from portrait to landscape
- The Collapsible state remained `open` but the trigger button was hidden by CSS (display:none above 768px), leaving no way to close it
- Made the Collapsible controlled and added a `matchMedia` listener that auto-closes it when the viewport exceeds the mobile breakpoint

## Test plan

- [ ] Open the app on a mobile device (or browser devtools mobile emulation) in portrait mode
- [ ] Open the hamburger nav
- [ ] Rotate to landscape — nav should close automatically
- [ ] Verify the hamburger still toggles correctly in portrait mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)